### PR TITLE
exclude arg

### DIFF
--- a/PHPCPD/TextUI/Command.php
+++ b/PHPCPD/TextUI/Command.php
@@ -182,6 +182,10 @@ class PHPCPD_TextUI_Command
 
         $arguments  = $input->getArguments();
         $exclude    = $input->getOption('exclude')->value;
+        if (is_array($exclude) && (count($exclude) == 1)) {
+            $exclude = explode(',', array_pop($exclude));
+            array_map('trim', $exclude);
+        }
         $logPmd     = $input->getOption('log-pmd')->value;
         $minLines   = $input->getOption('min-lines')->value;
         $minTokens  = $input->getOption('min-tokens')->value;


### PR DESCRIPTION
I needed to exclude a bunch of folders when running phpcpd, and specifying multiple --exclude args on the command line was bothering me. Also, several other tools I use in the same ant file (pdepend, phpmd, phpcs) already allow a list of comma-separated names to ignore. This way I can use an ant build property to manage the ignore list in one place. Even -suffixes arg. in phpcpd itself allows it. So, I added support for that, in a similar way it is done for --suffixes. It only happens if you provided one (and only one) --exclude.
