### PR TITLE
Fixes Undefined Index bug in getCommonPath()

### DIFF
--- a/PHPCPD/TextUI/Command.php
+++ b/PHPCPD/TextUI/Command.php
@@ -246,11 +246,11 @@ class PHPCPD_TextUI_Command
 
         $_files = array();
 
-        for ($i = 0; $i < $count; $i++) {
-            $_files[$i] = explode(DIRECTORY_SEPARATOR, $files[$i]);
+        foreach ($files as $file) {
+            $_files[] = $_fileParts = explode(DIRECTORY_SEPARATOR, $file);
 
-            if (empty($_files[$i][0])) {
-                $_files[$i][0] = DIRECTORY_SEPARATOR;
+            if (empty($_fileParts[0])) {
+                $_fileParts[0] = DIRECTORY_SEPARATOR;
             }
         }
 


### PR DESCRIPTION
The `getCommonPath(array $files)` method assumes the passed in `$files` array to contain filepaths in consecutive order, e.g.

```
array( '0' => '/path/to/foo', '1' => '/path/to/bar', …, 'n' => '/path/to/baz');
```

When an array is passed in without consecutive keys, e.g. 

```
array( '0' => '/path/to/foo', '42' => '/path/to/bar', …, 'n' => '/path/to/baz');
```

Undefined Index Notices are being raised and the method will finish without processing all items in the array. The attached patch fixes this by replacing the `for` loop with a `foreach`.
