### PR TITLE
Add a --quite flag that prohibits the output of each found duplicate.

### DIFF
--- a/PHPCPD/TextUI/Command.php
+++ b/PHPCPD/TextUI/Command.php
@@ -126,6 +126,16 @@ class PHPCPD_TextUI_Command
 
         $input->registerOption(
           new ezcConsoleOption(
+            '',
+            'quite',
+            ezcConsoleInput::TYPE_NONE,
+            NULL,
+            FALSE
+           )
+        );
+
+        $input->registerOption(
+          new ezcConsoleOption(
             'v',
             'version',
             ezcConsoleInput::TYPE_NONE,
@@ -213,7 +223,7 @@ class PHPCPD_TextUI_Command
         );
 
         $printer = new PHPCPD_TextUI_ResultPrinter;
-        $printer->printResult($clones, $commonPath);
+        $printer->printResult($clones, $commonPath, !$input->getOption('quite')->value);
         unset($printer);
 
         if ($logPmd) {
@@ -262,6 +272,7 @@ Usage: phpcpd [switches] <directory|file> ...
   --help                   Prints this usage information.
   --version                Prints the version and exits.
 
+  --quite                  Only print the final summary.
   --verbose                Print progress bar.
 
 EOT;

--- a/PHPCPD/TextUI/ResultPrinter.php
+++ b/PHPCPD/TextUI/ResultPrinter.php
@@ -58,8 +58,9 @@ class PHPCPD_TextUI_ResultPrinter
      *
      * @param PHPCPD_CloneMap $clones
      * @param string          $commonPath
+     * @param bool            $verbose
      */
-    public function printResult(PHPCPD_CloneMap $clones, $commonPath)
+    public function printResult(PHPCPD_CloneMap $clones, $commonPath, $verbose)
     {
         $numClones = count($clones);
 
@@ -79,23 +80,25 @@ class PHPCPD_TextUI_ResultPrinter
 
                 $lines += $clone->size;
 
-                $buffer .= sprintf(
-                  "\n  - %s:%d-%d\n    %s:%d-%d\n",
-                  str_replace($commonPath, '', $clone->aFile),
-                  $clone->aStartLine,
-                  $clone->aStartLine + $clone->size,
-                  str_replace($commonPath, '', $clone->bFile),
-                  $clone->bStartLine,
-                  $clone->bStartLine + $clone->size
-                );
+                if($verbose) {
+                    $buffer .= sprintf(
+                      "\n  - %s:%d-%d\n    %s:%d-%d\n",
+                      str_replace($commonPath, '', $clone->aFile),
+                      $clone->aStartLine,
+                      $clone->aStartLine + $clone->size,
+                      str_replace($commonPath, '', $clone->bFile),
+                      $clone->bStartLine,
+                      $clone->bStartLine + $clone->size
+                    );
+                }
             }
 
             printf(
-              "Found %d exact clones with %d duplicated lines in %d files:\n%s",
+              "Found %d exact clones with %d duplicated lines in %d files%s",
               $numClones,
               $lines,
               count($files),
-              $buffer
+              $verbose ? ":\n".$buffer : ".\n"
             );
         }
 


### PR DESCRIPTION
This can be usefull when using in CI context with --log-pmd to reduce the amount of generated console output.
