### PR TITLE
Fix notice in command. 

### DIFF
--- a/PHPCPD/TextUI/Command.php
+++ b/PHPCPD/TextUI/Command.php
@@ -238,6 +238,7 @@ class PHPCPD_TextUI_Command
      */
     protected static function getCommonPath(array $files)
     {
+        $files = array_values($files);
         $count = count($files);
 
         if ($count == 1) {


### PR DESCRIPTION
This commit fixes a notice that happens if the files array contains gaps, for exampel because of an unset during an earlier filterstep.

Part of the output I saw (on Ubuntu 10.10):
tarjei@k4v:~/Zero/div/ZeroCMS$ phpcpd src/
phpcpd 1.3.2 by Sebastian Bergmann.

PHP Notice:  Undefined offset: 9 in /usr/share/php/PHPCPD/TextUI/Command.php on line 252
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpcpd:0
PHP   2. PHPCPD_TextUI_Command::main() /usr/bin/phpcpd:51
PHP   3. PHPCPD_TextUI_Command::getCommonPath() /usr/share/php/PHPCPD/TextUI/Command.php:219
PHP Notice:  Undefined offset: 10 in /usr/share/php/PHPCPD/TextUI/Command.php on line 252
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpcpd:0
PHP   2. PHPCPD_TextUI_Command::main() /usr/bin/phpcpd:51
PHP   3. PHPCPD_TextUI_Command::getCommonPath() /usr/share/php/PHPCPD/TextUI/Command.php:219
PHP Notice:  Undefined offset: 11 in /usr/share/php/PHPCPD/TextUI/Command.php on line 252
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpcpd:0
PHP   2. PHPCPD_TextUI_Command::main() /usr/bin/phpcpd:51
PHP   3. PHPCPD_TextUI_Command::getCommonPath() /usr/share/php/PHPCPD/TextUI/Command.php:219
PHP Notice:  Undefined offset: 12 in /usr/share/php/PHPCPD/TextUI/Command.php on line 252
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpcpd:0
PHP   2. PHPCPD_TextUI_Command::main() /usr/bin/phpcpd:51
PHP   3. PHPCPD_TextUI_Command::getCommonPath() /usr/share/php/PHPCPD/TextUI/Command.php:219
PHP Notice:  Undefined offset: 13 in /usr/share/php/PHPCPD/TextUI/Command.php on line 252
PHP Stack trace:
