### PR TITLE
Workaround for PEAR #19133

### DIFF
--- a/PHPCPD/TextUI/Command.php
+++ b/PHPCPD/TextUI/Command.php
@@ -204,12 +204,21 @@ class PHPCPD_TextUI_Command
 
         if (!empty($arguments)) {
             $facade = new File_Iterator_Facade;
+            // Pre-check before passing buggy $commonPath = true
+            // TODO: revert this back once PEAR #19133 is fixed
+            $files = array();
             $result = $facade->getFilesAsArray(
-              $arguments, $suffixes, array(), $exclude, TRUE
+              $arguments, $suffixes, array(), $exclude, FALSE
             );
 
-            $files      = $result['files'];
-            $commonPath = $result['commonPath'];
+            if ($result) {
+                $result = $facade->getFilesAsArray(
+                  $arguments, $suffixes, array(), $exclude, TRUE
+                );
+
+                $files      = $result['files'];
+                $commonPath = $result['commonPath'];
+            }
 
             unset($result);
         } else {


### PR DESCRIPTION
Look for matching files without using $commonPath
to pre-check if it's worth performing the buggy call. It
leads to double iteration but that's rally better that the
current endless loop caused by PEAR #19133

To reproduce:

mkdir testdir
phpcpd testdir

Hope it helps, ciao :-)
