### PR TITLE
Add support for --excluded_names option

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -133,6 +133,17 @@ namespace SebastianBergmann\PHPCPD\TextUI
             $input->registerOption(
               new \ezcConsoleOption(
                 '',
+                'excluded_names',
+                \ezcConsoleInput::TYPE_STRING,
+                '',
+                FALSE
+               )
+            );
+
+
+            $input->registerOption(
+              new \ezcConsoleOption(
+                '',
                 'quiet',
                 \ezcConsoleInput::TYPE_NONE,
                 NULL,
@@ -204,6 +215,7 @@ namespace SebastianBergmann\PHPCPD\TextUI
             $minLines   = $input->getOption('min-lines')->value;
             $minTokens  = $input->getOption('min-tokens')->value;
             $names      = explode(',', $input->getOption('names')->value);
+            $excluded_names = explode(',', $input->getOption('excluded_names')->value);
             $quiet      = $input->getOption('quiet')->value;
             $verbose    = $input->getOption('verbose')->value;
 
@@ -217,7 +229,7 @@ namespace SebastianBergmann\PHPCPD\TextUI
 
             $this->printVersionString();
 
-            $finder = new FinderFacade($arguments, $excludes, $names);
+            $finder = new FinderFacade($arguments, $excludes, $names, $excluded_names);
             $files  = $finder->findFiles();
 
             if (empty($files)) {
@@ -278,6 +290,8 @@ Usage: phpcpd [switches] <directory|file> ...
   --exclude <dir>          Exclude <dir> from code analysis.
   --names <names>          A comma-separated list of file names to check.
                            (default: *.php)
+
+  --excluded_names <names> A comma-separated list of file names to exclude from check.
 
   --help                   Prints this usage information.
   --version                Prints the version and exits.


### PR DESCRIPTION
This pull request is tightly related to this pull request: https://github.com/sebastianbergmann/finder-facade/pull/4. 

This change adds support for --excluded_names option in phpcpd. This allows to filter out files, basing on pattern(s) provided by user. Most logic is implemented on library level, so this change is minor. 

Motivation for this change is described at related pull request
