### PR TITLE
Fixes autoload error

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -41,10 +41,7 @@
  * @since     File available since Release 1.1.0
  */
 
-require_once 'SebastianBergmann/FinderFacade/autoload.php';
-require_once 'SebastianBergmann/Version/autoload.php';
-require_once 'PHP/Timer/Autoload.php';
-require_once 'ezc/Base/base.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 spl_autoload_register(
     function($class) {


### PR DESCRIPTION
Fixes the error  "PHP Warning:  require_once(SebastianBergmann/FinderFacade/autoload.php): failed to open stream: No such file or directory" by delegating autoload to vendor autoload of composer.

This error occurs on all install methods, except PEAR:
- a dev checkout
- tag dist download
- composer require-dev 
- and the PHAR distribution.
