### PR TITLE
Require ext-iconv in composer manifest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     },
     "require": {
         "php": ">=5.3.3",
+        "ext-iconv": "*",
         "zetacomponents/base": ">=1.8",
         "zetacomponents/console-tools": ">=1.6",
         "sebastian/finder-facade": "~1.1",


### PR DESCRIPTION
Without iconv phpcpd won't work, so let composer check for the availability.
