### PR TITLE
Added missing CodeCloneFile.php to package.xml

### DIFF
--- a/build/package.xml
+++ b/build/package.xml
@@ -50,6 +50,7 @@
      </dir>
      <file baseinstalldir="/" name="autoload.php" role="php" />
      <file baseinstalldir="/" name="CodeClone.php" role="php" />
+     <file baseinstalldir="/" name="CodeCloneFile.php" role="php" />
      <file baseinstalldir="/" name="CodeCloneMap.php" role="php" />
     </dir>
    </dir>


### PR DESCRIPTION
When 2.0.0-BETA1 is installed via PEAR, the file `CodeCloneFile.php` is missing. This seems
to be caused by a missing entry in `package.xml`.
