### PR TITLE
Decoupled tokenizer from detection strategy

### DIFF
--- a/build/package.xml
+++ b/build/package.xml
@@ -38,10 +38,15 @@
      </dir>
      <dir name="Detector">
       <dir name="Strategy">
-      <file baseinstalldir="/" name="Abstract.php" role="php" />
-      <file baseinstalldir="/" name="Default.php" role="php" />
+       <file baseinstalldir="/" name="Abstract.php" role="php" />
+       <file baseinstalldir="/" name="Default.php" role="php" />
+      </dir>
+      <dir name="Tokenizer">
+       <file baseinstalldir="/" name="PHP.php" role="php" />
+       <file baseinstalldir="/" name="Result.php" role="php" />
       </dir>
       <file baseinstalldir="/" name="Detector.php" role="php" />
+      <file baseinstalldir="/" name="Tokenizer.php" role="php" />
      </dir>
      <dir name="Log">
       <file baseinstalldir="/" name="AbstractXmlLogger.php" role="php" />

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -45,6 +45,7 @@ namespace SebastianBergmann\PHPCPD\CLI;
 
 use SebastianBergmann\PHPCPD\Detector\Detector;
 use SebastianBergmann\PHPCPD\Detector\Strategy\DefaultStrategy;
+use SebastianBergmann\PHPCPD\Detector\Tokenizer\PHP;
 use SebastianBergmann\PHPCPD\Log\PMD;
 use SebastianBergmann\PHPCPD\Log\Text;
 use SebastianBergmann\FinderFacade\FinderFacade;
@@ -162,9 +163,10 @@ class Command extends AbstractCommand
             $progressHelper->start($output, count($files));
         }
 
-        $strategy = new DefaultStrategy;
-        $detector = new Detector($strategy, $progressHelper);
-        $quiet    = $output->getVerbosity() == OutputInterface::VERBOSITY_QUIET;
+        $tokenizer = new PHP;
+        $strategy  = new DefaultStrategy($tokenizer);
+        $detector  = new Detector($strategy, $progressHelper);
+        $quiet     = $output->getVerbosity() == OutputInterface::VERBOSITY_QUIET;
 
         $clones = $detector->copyPasteDetection(
             $files,

--- a/src/Detector/Strategy/Default.php
+++ b/src/Detector/Strategy/Default.php
@@ -46,6 +46,7 @@ namespace SebastianBergmann\PHPCPD\Detector\Strategy;
 use SebastianBergmann\PHPCPD\CodeClone;
 use SebastianBergmann\PHPCPD\CodeCloneFile;
 use SebastianBergmann\PHPCPD\CodeCloneMap;
+use SebastianBergmann\PHPCPD\Detector\Tokenizer;
 
 /**
  * Default strategy for detecting code clones.
@@ -60,6 +61,22 @@ use SebastianBergmann\PHPCPD\CodeCloneMap;
 class DefaultStrategy extends AbstractStrategy
 {
     /**
+     * @var Tokenizer
+     */
+    private $tokenizer;
+
+    /**
+     * Constructor.
+     *
+     * @param Tokenizer $tokenizer
+     * @since Method available since Release 2.0.0
+     */
+    public function __construct(Tokenizer $tokenizer)
+    {
+        $this->tokenizer = $tokenizer;
+    }
+
+    /**
      * Copy & Paste Detection (CPD).
      *
      * @param  string       $file
@@ -71,19 +88,20 @@ class DefaultStrategy extends AbstractStrategy
      */
     public function processFile($file, $minLines, $minTokens, CodeCloneMap $result, $fuzzy = false)
     {
-        $buffer                    = file_get_contents($file);
+        $tokenizerResult = $this->tokenizer->tokenizeFile($file);
+
         $currentTokenPositions     = array();
         $currentTokenRealPositions = array();
         $currentSignature          = '';
-        $tokens                    = token_get_all($buffer);
+        $tokens                    = $tokenizerResult->getTokens();
         $tokenNr                   = 0;
         $lastTokenLine             = 0;
 
         $result->setNumLines(
-            $result->getNumLines() + substr_count($buffer, "\n")
+            $result->getNumLines() + $tokenizerResult->getNumberOfLines()
         );
 
-        unset($buffer);
+        unset($tokenizerResult);
 
         foreach (array_keys($tokens) as $key) {
             $token = $tokens[$key];

--- a/src/Detector/Tokenizer.php
+++ b/src/Detector/Tokenizer.php
@@ -38,38 +38,31 @@
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
  * @copyright 2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
- * @since     File available since Release 1.1.0
+ * @since     File available since Release 2.0.0
  */
 
-require_once 'SebastianBergmann/FinderFacade/autoload.php';
-require_once 'SebastianBergmann/Version/autoload.php';
-require_once 'Symfony/Component/Console/autoloader.php';
-require_once 'PHP/Timer/Autoload.php';
+namespace SebastianBergmann\PHPCPD\Detector;
 
-spl_autoload_register(
-    function ($class) {
-        static $classes = null;
-        if ($classes === null) {
-            $classes = array(
-              'sebastianbergmann\\phpcpd\\cli\\application' => '/CLI/Application.php',
-              'sebastianbergmann\\phpcpd\\cli\\command' => '/CLI/Command.php',
-              'sebastianbergmann\\phpcpd\\codeclone' => '/CodeClone.php',
-              'sebastianbergmann\\phpcpd\\codeclonefile' => '/CodeCloneFile.php',
-              'sebastianbergmann\\phpcpd\\codeclonemap' => '/CodeCloneMap.php',
-              'sebastianbergmann\\phpcpd\\detector\\detector' => '/Detector/Detector.php',
-              'sebastianbergmann\\phpcpd\\detector\\strategy\\abstractstrategy' => '/Detector/Strategy/Abstract.php',
-              'sebastianbergmann\\phpcpd\\detector\\strategy\\defaultstrategy' => '/Detector/Strategy/Default.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer' => '/Detector/Tokenizer.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer\\php' => '/Detector/Tokenizer/PHP.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer\\result' => '/Detector/Tokenizer/Result.php',
-              'sebastianbergmann\\phpcpd\\log\\abstractxmllogger' => '/Log/AbstractXmlLogger.php',
-              'sebastianbergmann\\phpcpd\\log\\pmd' => '/Log/PMD.php',
-              'sebastianbergmann\\phpcpd\\log\\text' => '/Log/Text.php'
-            );
-        }
-        $cn = strtolower($class);
-        if (isset($classes[$cn])) {
-            require __DIR__ . $classes[$cn];
-        }
-    }
-);
+use SebastianBergmann\PHPCPD\Detector\Tokenizer\Result;
+
+/**
+ * Interface for a tokenizer, which reads a file and splits it
+ * into lexical tokens.
+ *
+ * @author    Johann-Peter Hartmann <johann-peter.hartmann@mayflower.de>
+ * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright 2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link      http://github.com/sebastianbergmann/phpcpd/tree
+ * @since     Class available since Release 2.0.0
+ */
+interface Tokenizer
+{
+    /**
+     * Tokenizes a file.
+     *
+     * @param  string       $file
+     * @return Result
+     */
+    public function tokenizeFile($file);
+}

--- a/src/Detector/Tokenizer/PHP.php
+++ b/src/Detector/Tokenizer/PHP.php
@@ -38,38 +38,37 @@
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
  * @copyright 2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
- * @since     File available since Release 1.1.0
+ * @since     File available since Release 2.0.0
  */
 
-require_once 'SebastianBergmann/FinderFacade/autoload.php';
-require_once 'SebastianBergmann/Version/autoload.php';
-require_once 'Symfony/Component/Console/autoloader.php';
-require_once 'PHP/Timer/Autoload.php';
+namespace SebastianBergmann\PHPCPD\Detector\Tokenizer;
 
-spl_autoload_register(
-    function ($class) {
-        static $classes = null;
-        if ($classes === null) {
-            $classes = array(
-              'sebastianbergmann\\phpcpd\\cli\\application' => '/CLI/Application.php',
-              'sebastianbergmann\\phpcpd\\cli\\command' => '/CLI/Command.php',
-              'sebastianbergmann\\phpcpd\\codeclone' => '/CodeClone.php',
-              'sebastianbergmann\\phpcpd\\codeclonefile' => '/CodeCloneFile.php',
-              'sebastianbergmann\\phpcpd\\codeclonemap' => '/CodeCloneMap.php',
-              'sebastianbergmann\\phpcpd\\detector\\detector' => '/Detector/Detector.php',
-              'sebastianbergmann\\phpcpd\\detector\\strategy\\abstractstrategy' => '/Detector/Strategy/Abstract.php',
-              'sebastianbergmann\\phpcpd\\detector\\strategy\\defaultstrategy' => '/Detector/Strategy/Default.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer' => '/Detector/Tokenizer.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer\\php' => '/Detector/Tokenizer/PHP.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer\\result' => '/Detector/Tokenizer/Result.php',
-              'sebastianbergmann\\phpcpd\\log\\abstractxmllogger' => '/Log/AbstractXmlLogger.php',
-              'sebastianbergmann\\phpcpd\\log\\pmd' => '/Log/PMD.php',
-              'sebastianbergmann\\phpcpd\\log\\text' => '/Log/Text.php'
-            );
-        }
-        $cn = strtolower($class);
-        if (isset($classes[$cn])) {
-            require __DIR__ . $classes[$cn];
-        }
+use SebastianBergmann\PHPCPD\Detector\Tokenizer;
+
+/**
+ * A tokenizer for PHP source files.
+ *
+ * @author    Johann-Peter Hartmann <johann-peter.hartmann@mayflower.de>
+ * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright 2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link      http://github.com/sebastianbergmann/phpcpd/tree
+ * @since     Class available since Release 2.0.0
+ */
+class PHP implements Tokenizer
+{
+    /**
+     * Tokenizes a PHP file.
+     *
+     * @param  string $file
+     * @return Result
+     */
+    public function tokenizeFile($file)
+    {
+        $buffer = file_get_contents($file);
+        $tokens = token_get_all($buffer);
+        $numberOfLines = substr_count($buffer, "\n");
+
+        return new Result($tokens, $numberOfLines);
     }
-);
+}

--- a/src/Detector/Tokenizer/Result.php
+++ b/src/Detector/Tokenizer/Result.php
@@ -38,38 +38,64 @@
  * @author    Sebastian Bergmann <sebastian@phpunit.de>
  * @copyright 2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
- * @since     File available since Release 1.1.0
+ * @since     File available since Release 2.0.0
  */
 
-require_once 'SebastianBergmann/FinderFacade/autoload.php';
-require_once 'SebastianBergmann/Version/autoload.php';
-require_once 'Symfony/Component/Console/autoloader.php';
-require_once 'PHP/Timer/Autoload.php';
+namespace SebastianBergmann\PHPCPD\Detector\Tokenizer;
 
-spl_autoload_register(
-    function ($class) {
-        static $classes = null;
-        if ($classes === null) {
-            $classes = array(
-              'sebastianbergmann\\phpcpd\\cli\\application' => '/CLI/Application.php',
-              'sebastianbergmann\\phpcpd\\cli\\command' => '/CLI/Command.php',
-              'sebastianbergmann\\phpcpd\\codeclone' => '/CodeClone.php',
-              'sebastianbergmann\\phpcpd\\codeclonefile' => '/CodeCloneFile.php',
-              'sebastianbergmann\\phpcpd\\codeclonemap' => '/CodeCloneMap.php',
-              'sebastianbergmann\\phpcpd\\detector\\detector' => '/Detector/Detector.php',
-              'sebastianbergmann\\phpcpd\\detector\\strategy\\abstractstrategy' => '/Detector/Strategy/Abstract.php',
-              'sebastianbergmann\\phpcpd\\detector\\strategy\\defaultstrategy' => '/Detector/Strategy/Default.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer' => '/Detector/Tokenizer.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer\\php' => '/Detector/Tokenizer/PHP.php',
-              'sebastianbergmann\\phpcpd\\detector\\tokenizer\\result' => '/Detector/Tokenizer/Result.php',
-              'sebastianbergmann\\phpcpd\\log\\abstractxmllogger' => '/Log/AbstractXmlLogger.php',
-              'sebastianbergmann\\phpcpd\\log\\pmd' => '/Log/PMD.php',
-              'sebastianbergmann\\phpcpd\\log\\text' => '/Log/Text.php'
-            );
-        }
-        $cn = strtolower($class);
-        if (isset($classes[$cn])) {
-            require __DIR__ . $classes[$cn];
-        }
+/**
+ * Value object that represents the output of tokenizing a file.
+ *
+ * @author    Johann-Peter Hartmann <johann-peter.hartmann@mayflower.de>
+ * @author    Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright 2009-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license   http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link      http://github.com/sebastianbergmann/phpcpd/tree
+ * @since     Class available since Release 2.0.0
+ */
+class Result
+{
+    /**
+     * @var array
+     */
+    private $tokens;
+
+    /**
+     * @var integer
+     */
+    private $numberOfLines;
+
+    /**
+     * Constructor.
+     *
+     * @param array   $tokens           Array of tokens, in the same format
+     *                                  as token_get_all() returns them.
+     * @param integer $numberOfLines  The number of lines in the read file.
+     */
+    public function __construct(array $tokens, $numberOfLines)
+    {
+        $this->tokens = $tokens;
+        $this->numberOfLines = $numberOfLines;
     }
-);
+
+    /**
+     * Returns the tokens that were read from the file.
+     *
+     * @return array        Array of tokens, in the same format
+     *                      as token_get_all() returns them.
+     */
+    public function getTokens()
+    {
+        return $this->tokens;
+    }
+
+    /**
+     * Returns the number of lines in the file.
+     *
+     * @return integer
+     */
+    public function getNumberOfLines()
+    {
+        return $this->numberOfLines;
+    }
+}

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -66,7 +66,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testDetectingSimpleClonesWorks($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
 
         $clones = $detector->copyPasteDetection(
           array(TEST_FILES_PATH . 'Math.php')
@@ -157,7 +157,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testDetectingExactDuplicateFilesWorks($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
 
         $clones = $detector->copyPasteDetection(array(
           TEST_FILES_PATH . 'a.php',
@@ -186,7 +186,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testDetectingClonesInMoreThanTwoFiles($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
 
         $clones = $detector->copyPasteDetection(
           array(
@@ -223,7 +223,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testClonesAreIgnoredIfTheySpanLessTokensThanMinTokens($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
 
         $clones = $detector->copyPasteDetection(
           array(
@@ -243,7 +243,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testClonesAreIgnoredIfTheySpanLessLinesThanMinLines($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
 
         $clones = $detector->copyPasteDetection(
           array(
@@ -263,7 +263,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testFuzzyClonesAreFound($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
 
         $clones = $detector->copyPasteDetection(
           array(
@@ -286,7 +286,7 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
      */
     public function testStripComments($strategy)
     {
-        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $detector = $this->createDetector($strategy);
         $clones = $detector->copyPasteDetection(
             array(
                 TEST_FILES_PATH . 'e.php',
@@ -310,6 +310,14 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
         );
         $clones = $clones->getClones();
         $this->assertCount(1, $clones);
+    }
+
+    private function createDetector($strategyClass)
+    {
+        $tokenizer = new SebastianBergmann\PHPCPD\Detector\Tokenizer\PHP();
+        $strategy  = new $strategyClass($tokenizer);
+
+        return new SebastianBergmann\PHPCPD\Detector\Detector($strategy);
     }
 
     public function strategyProvider()


### PR DESCRIPTION
This opens up possibilities to swap the default token_get_all()-
based tokenizer for another one, or to add tokenizers for other
programming languages.
