### PR TITLE
Fix #85

### DIFF
--- a/src/Log/AbstractXmlLogger.php
+++ b/src/Log/AbstractXmlLogger.php
@@ -132,6 +132,30 @@ abstract class AbstractXmlLogger
     }
 
     /**
+     * Escapes a string for inclusion inside an XML tag.
+     *
+     * Converts the string to UTF-8, substitutes the unicode replacement
+     * character for every character disallowed in XML, and escapes
+     * special characters.
+     *
+     * @param  string $string
+     * @return string
+     */
+    protected function escapeForXml($string)
+    {
+        $string = $this->convertToUtf8($string);
+
+        // Substitute the unicode replacement character for disallowed chars
+        $string = preg_replace(
+            '/[^\x09\x0A\x0D\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]/u',
+            "\xEF\xBF\xBD",
+            $string
+        );
+
+        return htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
+    }
+
+    /**
      * Processes a list of clones.
      *
      * @param CodeCloneMap $clones

--- a/src/Log/PMD.php
+++ b/src/Log/PMD.php
@@ -87,11 +87,7 @@ class PMD extends AbstractXmlLogger
             $duplication->appendChild(
                 $this->document->createElement(
                     'codefragment',
-                    htmlspecialchars(
-                        $this->convertToUtf8($clone->getLines()),
-                        ENT_COMPAT,
-                        'UTF-8'
-                    )
+                    $this->escapeForXml($clone->getLines())
                 )
             );
         }

--- a/tests/Log/PMDTest.php
+++ b/tests/Log/PMDTest.php
@@ -1,0 +1,70 @@
+<?php
+use SebastianBergmann\PHPCPD\CodeClone;
+use SebastianBergmann\PHPCPD\CodeCloneFile;
+use SebastianBergmann\PHPCPD\CodeCloneMap;
+use SebastianBergmann\PHPCPD\Log\PMD;
+
+class PHPCPD_Log_PMDTest extends PHPUnit_Framework_TestCase
+{
+    /** @var string */
+    private $testFile1;
+    /** @var @var string */
+    private $testFile2;
+    /** @var string */
+    private $pmdLogFile;
+    /** @var string */
+    private $expectedPmdLogFile;
+    /** @var \SebastianBergmann\PHPCPD\Log\PMD */
+    private $pmdLogger;
+
+    protected function setUp()
+    {
+        $this->testFile1 = __DIR__ . '/_files/with_ascii_escape.php';
+        $this->testFile2 = __DIR__ . '/_files/with_ascii_escape2.php';
+
+        $this->pmdLogFile = tempnam(sys_get_temp_dir(), 'pmd');
+
+        $this->expectedPmdLogFile = tempnam(sys_get_temp_dir(), 'pmd');
+        $expectedPmdLogTemplate = __DIR__ . '/_files/pmd_expected.xml';
+        $expectedPmdLogContents = strtr(
+            file_get_contents($expectedPmdLogTemplate),
+            array(
+                '%file1%' => $this->testFile1,
+                '%file2%' => $this->testFile2
+            )
+        );
+        file_put_contents($this->expectedPmdLogFile, $expectedPmdLogContents);
+
+        $this->pmdLogger = new PMD($this->pmdLogFile);
+    }
+
+    protected function tearDown()
+    {
+        if (file_exists($this->pmdLogFile)) {
+            unlink($this->pmdLogFile);
+        }
+        if (file_exists($this->expectedPmdLogFile)) {
+            unlink($this->expectedPmdLogFile);
+        }
+    }
+
+    /**
+     * @covers       SebastianBergmann\PHPCPD\Log\PMD
+     * @covers       SebastianBergmann\PHPCPD\Log\AbstractXmlLogger
+     */
+    public function testSubstitutesDisallowedCharacters()
+    {
+        $file1 = new CodeCloneFile($this->testFile1, 8);
+        $file2 = new CodeCloneFile($this->testFile2, 8);
+        $clone = new CodeClone($file1, $file2, 4, 4);
+        $cloneMap = new CodeCloneMap();
+        $cloneMap->addClone($clone);
+
+        $this->pmdLogger->processClones($cloneMap);
+
+        $this->assertXmlFileEqualsXmlFile(
+            $this->expectedPmdLogFile,
+            $this->pmdLogFile
+        );
+    }
+}

--- a/tests/Log/_files/pmd_expected.xml
+++ b/tests/Log/_files/pmd_expected.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd-cpd>
+    <duplication lines="4" tokens="4">
+        <file path="%file1%" line="8"/>
+        <file path="%file2%" line="8"/>
+        <codefragment>function getAsciiEscapeChar()
+{
+    return "�";
+}
+</codefragment>
+    </duplication>
+</pmd-cpd>

--- a/tests/Log/_files/with_ascii_escape.php
+++ b/tests/Log/_files/with_ascii_escape.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * This function returns an ASCII escape character:
+ *
+ * @return string
+ */
+function getAsciiEscapeChar()
+{
+    return "";
+}


### PR DESCRIPTION
The PMD logger now replaces all characters that are invalid in XML
by the Unicode replacement character (U+FFFD).
