### PR TITLE
carriage return removed to have a clearer display in less

### DIFF
--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -88,7 +88,7 @@ class Text
 
                 foreach ($clone->getFiles() as $file) {
                     $buffer .= sprintf(
-                        "\r\t%s:%d-%d\n ",
+                        "\t%s:%d-%d\n ",
                         $file->getName(),
                         $file->getStartLine(),
                         $file->getStartLine() + $clone->getSize()


### PR DESCRIPTION
When seeing the result of phpcpd with less, \r characters at the begining of the lines are polluting the output:

```
> phpcpd -v --min-lines 1 --min-tokens 1 /tmp/test1.php /tmp/test2.php  | less
phpcpd 2.0.0 by Sebastian Bergmann.

Found 2 exact clones with 3 duplicated lines in 2 files:

  -^M   /tmp/test1.php:3-4
 ^M     /tmp/test1.php:4-5

echo "common line:";

  -^M   /tmp/test1.php:3-5
 ^M     /tmp/test2.php:3-5

echo "common line:";
echo 1;

37.50% duplicated lines out of 8 total lines of code.

Time: 14 ms, Memory: 2.00Mb
(END)

```

Without the carriage return, the output is cleaned and the render is unchanged on mac and windows.

Please let me know if something is wrong with this change.

Regards,

Ghislain Rodrigues
