### PR TITLE
Return the number of clones instead of exiting.

### DIFF
--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -111,7 +111,7 @@ class Application extends AbstractApplication
      * @param InputInterface  $input  An Input instance
      * @param OutputInterface $output An Output instance
      *
-     * @return integer 0 if everything went fine, or an error code
+     * @return integer 0 if everything went fine, or the number of clones found.
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
@@ -133,6 +133,6 @@ class Application extends AbstractApplication
             $input = new ArrayInput(array('--help'));
         }
 
-        parent::doRun($input, $output);
+        return parent::doRun($input, $output);
     }
 }

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -138,7 +138,7 @@ class Command extends AbstractCommand
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
      *
-     * @return null|integer null or 0 if everything went fine, or an error code
+     * @return null|integer null or 0 if everything went fine, or the number of clones found.
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -197,9 +197,7 @@ class Command extends AbstractCommand
             print \PHP_Timer::resourceUsage() . "\n";
         }
 
-        if (count($clones) > 0) {
-            exit(1);
-        }
+        return count($clones);
     }
 
     /**


### PR DESCRIPTION
Hello,
I'd like to use phpcpd from within another application and in conjunction with other CI tools like phpcs, phpunit etc. being installed using Composer.
I use the following code:

``` php
class MyApplication...
{
    someFunction()
    {
        $application = new \SebastianBergmann\PHPCPD\CLI\Application;

        $application->setAutoExit(false);

        $cloneCount = $application->run(
            new ArrayInput(
                ['values' => [
                    JPATH_ROOT . '/cli',
                    JPATH_ROOT . '/src'
                ]]
            )
        );
        // more code..
    }
}
```

which works fine except the fact that if clones are found phpcpd will `exit()` so my application "dies"...

So the idea here is to return the number of clones found (or zero) instead of hard exiting. I know this a a bit "unorthodox", but it works. The only limit here would be that only 255 clones will be displayed as this is the maximum error status, but well ;)

Another (and of course "cleaner") option would be to return `1`, so the SymphonyApplication will exit with this status code (if `autoExit` isn't set to `false`).

BTW: here is a Travis log of our custom script invoking phpcs and phpunit using a similar technique described earlier: https://travis-ci.org/joomla/jissues/jobs/21904034
The scripts invoking those can be found here: https://github.com/joomla/jissues/tree/master/cli/Application/Command/Test
This is a Joomla! Application :wink: 
