### PR TITLE
[RFR] Add a regexps-exclude option

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -93,6 +93,13 @@ class Command extends AbstractCommand
                  array()
              )
              ->addOption(
+                 'regexps-exclude',
+                 null,
+                 InputOption::VALUE_REQUIRED,
+                 'A comma-separated list of paths regexps to exclude (example: "#var/.*_tmp#")',
+                 array()
+             )
+             ->addOption(
                  'exclude',
                  null,
                  InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
@@ -146,7 +153,8 @@ class Command extends AbstractCommand
             $input->getArgument('values'),
             $input->getOption('exclude'),
             $this->handleCSVOption($input, 'names'),
-            $this->handleCSVOption($input, 'names-exclude')
+            $this->handleCSVOption($input, 'names-exclude'),
+            $this->handleCSVOption($input, 'regexps-exclude')
         );
 
         $files = $finder->findFiles();


### PR DESCRIPTION
This PR adds a new `--regexps-exclude` option to counter a limitation with other options.

The `--names-exclude` option refers only to base name, which forbids to exclude a given path. For instance, if we want to exclude `web/app_*.php` it will not work. We have to exclude `app_*.php` through the `--names-exclude`. But it will also exclude `src/app_test.php` for instance.

The `--regexps-exclude` allows to specify a regexp which will then be inserted into the `notPath` method of the finder (a [PR on finder-facade](https://github.com/sebastianbergmann/finder-facade/pull/7) has been created). This way, we can exclude previous patterns with a command line such:

``` sh
phpcpd.phar --regexps-exclude '~web/app_.*\.php~' myProject
```

This PR can probably helps to fix some issues with the `--exclude` option, and should be an answer to #84.
