### PR TITLE
Changes return Code for No files found Message to 2 for Distinguishing

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -153,7 +153,7 @@ class Command extends AbstractCommand
 
         if (empty($files)) {
             $output->writeln('No files found to scan');
-            exit(1);
+            exit(2);
         }
 
         $progressHelper = null;


### PR DESCRIPTION
The Return Code can alternatively be 0.
See Issue #104 for reasoning.