### PR TITLE
update travis file for composer work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
-before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+install:
+  - travis_retry composer install --no-interaction --prefer-source
 
 php:
   - 5.3.3


### PR DESCRIPTION
- install deps in install section
- no need to self-update the composer
- no need for --dev as it is by default
- install deps using travis_retry
