### PR TITLE
Added php7 to travis allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ php:
 script: phpunit --configuration ./build/travis-ci.xml
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm
+    - php: 7.0
 
 notifications:
   email: false


### PR DESCRIPTION
I think that we should add the PHP7 to the allowed_failures for now. It's very likely that the BC will exists sooner or later and we don't want a Red build because of that.