### PR TITLE
Changed single quotes to double qoutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Simply add a dependency on `sebastian/phpcpd` to your project's `composer.json` 
 
 For a system-wide installation via Composer, you can run:
 
-    composer global require 'sebastian/phpcpd=*'
+    composer global require "sebastian/phpcpd=*"
 
 Make sure you have `~/.composer/vendor/bin/` in your path.
 


### PR DESCRIPTION
For some reason single quotes threw this error:

`Invalid version string "*'"` with `composer global require` on Windows 8.1
Changing single quotes to double quotes worked.