### PR TITLE
Adapted test expectation to code style changes in 51cf0bf

### DIFF
--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -40,12 +40,12 @@ class PHPCPD_DetectorTest extends PHPUnit_Framework_TestCase
         $file   = current($files);
 
         $this->assertEquals(TEST_FILES_PATH . 'Math.php', $file->getName());
-        $this->assertEquals(85, $file->getStartLine());
+        $this->assertEquals(75, $file->getStartLine());
 
         $file = next($files);
 
         $this->assertEquals(TEST_FILES_PATH . 'Math.php', $file->getName());
-        $this->assertEquals(149, $file->getStartLine());
+        $this->assertEquals(139, $file->getStartLine());
         $this->assertEquals(59, $clones[0]->getSize());
         $this->assertEquals(136, $clones[0]->getTokens());
 


### PR DESCRIPTION
Due to the changes in 51cf0bf the duplication now starts 10 lines earlier. This fixes the failing Travis build.