### PR TITLE
added --ignore-violations-on-exit flag for easier CI reporting integr…

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -93,6 +93,12 @@ class Command extends AbstractCommand
                  null,
                  InputOption::VALUE_NONE,
                  'Show progress bar'
+             )
+             ->addOption(
+                 'ignore-violations-on-exit',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Ignore violations and exit with status code 0'
              );
     }
 
@@ -162,7 +168,9 @@ class Command extends AbstractCommand
         }
 
         if (count($clones) > 0) {
-            exit(1);
+            if (!$input->getOption('ignore-violations-on-exit')) {
+                exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
For our CI setup, we wanted to be able to run `phpcpd` from a bash script and have it exit with a 0 status code each time (so it doesn't cause the build process to fail). This is because we are using `phpcpd` purely for reporting. 

I added a new optional command line argument: `--ignore-violations-on-exit` (this is the same syntax as the `phpmd` tool), which causes `phpcpd` to always exit with a 0 status code.

This may be useful to others. Please merge if you agree.

Regards!
