### PR TITLE
Add option `succeed-on-empty`

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -105,7 +105,7 @@ class Command extends AbstractCommand
                  'succeed-on-empty',
                  null,
                  InputOption::VALUE_NONE,
-                 'The command should fail when no files to scan are found'
+                 'The command should succeed when no files to scan are found'
              );
     }
 

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -100,6 +100,12 @@ class Command extends AbstractCommand
                  null,
                  InputOption::VALUE_NONE,
                  'Show progress bar'
+             )
+             ->addOption(
+                 'succeed-on-empty',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'The command should fail when no files to scan are found'
              );
     }
 
@@ -125,7 +131,7 @@ class Command extends AbstractCommand
 
         if (empty($files)) {
             $output->writeln('No files found to scan');
-            exit(1);
+            exit((int) $input->getOption('succeed-on-empty'));
         }
 
         $progressBar = null;


### PR DESCRIPTION
In our project templates `phpcpd` is running by default during the CI pipeline.
In a new project it happens quite often that there are no source files to scan yet.

This option allows to pass a flag to ignore the empty files when needed.