### PR TITLE
Update PMD.php

### DIFF
--- a/src/Log/PMD.php
+++ b/src/Log/PMD.php
@@ -46,12 +46,14 @@ class PMD extends AbstractXmlLogger
                 $file->setAttribute('line', $codeCloneFile->getStartLine());
             }
 
-            $duplication->appendChild(
+            $codefragment = $duplication->appendChild(
                 $this->document->createElement(
-                    'codefragment',
-                    $this->escapeForXml($clone->getLines())
+                    'codefragment'
                 )
             );
+            
+            $codefragment->appendChild($this->document->createCDATASection($this->escapeForXml($clone->getLines())));
+            
         }
 
         $this->flush();


### PR DESCRIPTION
at the first ... 
that line have a korea language.

i use to jenkins plugin, that name is `publish pmd anlysis result`.

and result.

org.xml.sax.SAXException: Input stream is not a PMD file.
	at hudson.plugins.pmd.parser.PmdParser.parse(PmdParser.java:72)
	at hudson.plugins.analysis.core.AbstractAnnotationParser.parse(AbstractAnnotationParser.java:54)
	at hudson.plugins.analysis.core.FilesParser.parseFile(FilesParser.java:325)
	at hudson.plugins.analysis.core.FilesParser.parseFiles(FilesParser.java:283)
	at hudson.plugins.analysis.core.FilesParser.parserCollectionOfFiles(FilesParser.java:234)
	at hudson.plugins.analysis.core.FilesParser.invoke(FilesParser.java:203)
	at hudson.plugins.analysis.core.FilesParser.invoke(FilesParser.java:31)
	at hudson.FilePath.act(FilePath.java:997)
	at hudson.FilePath.act(FilePath.java:975)
	at hudson.plugins.pmd.PmdPublisher.perform(PmdPublisher.java:76)
	at hudson.plugins.analysis.core.HealthAwarePublisher.perform(HealthAwarePublisher.java:68)
	at hudson.plugins.analysis.core.HealthAwareRecorder.perform(HealthAwareRecorder.java:295)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:720)
	at hudson.model.Build$BuildExecution.post2(Build.java:186)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:665)
	at hudson.model.Run.execute(Run.java:1760)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:405)




