### PR TITLE
New feature - issue 117 - Report average and maximum length of code c…

### DIFF
--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -25,6 +25,9 @@ final class Text
     {
         $verbose = $output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL;
 
+        $maxLength = 0;
+        $summedLength = 0;
+        $averageCounter = 0;
         if (\count($clones) > 0) {
             $output->write(
                 \sprintf(
@@ -50,6 +53,12 @@ final class Text
                     )
                 );
 
+                if($maxLength < $clone->getSize()) {
+                    $maxLength = $clone->getSize();
+                }
+                $summedLength += $clone->getSize();
+                $averageCounter++;
+
                 $firstOccurrence = false;
             }
 
@@ -62,9 +71,12 @@ final class Text
 
         $output->write(
             \sprintf(
-                "%s duplicated lines out of %d total lines of code.\n\n",
+                "%s duplicated lines out of %d total lines of code.\n" .
+                "Average size of duplication is %d lines, biggest clone has %d of lines\n",
                 $clones->getPercentage(),
-                $clones->getNumLines()
+                $clones->getNumLines(),
+                $summedLength / $averageCounter,
+                $maxLength
             )
         );
     }


### PR DESCRIPTION
Example output with current master of https://github.com/WordPress/WordPress

~/github/phpcpd(master)$ php -d memory_limit=512M phpcpd ../WordPress/
phpcpd 4.0.0-2-ged3cdd4 by Sebastian Bergmann.

Found 60 clones with 2721 duplicated lines in 41 files:

  - /home/developer/github/WordPress/wp-admin/includes/ajax-actions.php:3680-3710
    /home/developer/github/WordPress/wp-admin/includes/ajax-actions.php:3968-3998

...(shortened)

  - /home/developer/github/WordPress/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php:99-125
    /home/developer/github/WordPress/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:71-97

0.74% duplicated lines out of 366140 total lines of code.
Average size of duplication is 42 lines, biggest clone has 350 of lines
Time: 1.94 seconds, Memory: 272.00MB


42 o_0