### PR TITLE
[#162] Nullables are respected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,8 @@
         "branch-alias": {
             "dev-master": "4.0-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.3"
     }
 }

--- a/src/Detector/Strategy/DefaultStrategy.php
+++ b/src/Detector/Strategy/DefaultStrategy.php
@@ -35,6 +35,9 @@ class DefaultStrategy extends AbstractStrategy
         foreach (\array_keys($tokens) as $key) {
             $token = $tokens[$key];
 
+            if (is_string($token) && $token === '?') {
+                $token = [0, '?', $lastTokenLine];
+            }
             if (\is_array($token)) {
                 if (!isset($this->tokensIgnoreList[$token[0]])) {
                     if ($tokenNr === 0) {

--- a/tests/DetectorTest.php
+++ b/tests/DetectorTest.php
@@ -46,7 +46,7 @@ class PHPCPD_DetectorTest extends TestCase
         $this->assertEquals(TEST_FILES_PATH . 'Math.php', $file->getName());
         $this->assertEquals(139, $file->getStartLine());
         $this->assertEquals(59, $clones[0]->getSize());
-        $this->assertEquals(136, $clones[0]->getTokens());
+        $this->assertEquals(138, $clones[0]->getTokens());
 
         $this->assertEquals(
           '    public function div($v1, $v2)
@@ -286,6 +286,27 @@ class PHPCPD_DetectorTest extends TestCase
         );
         $clones = $clones->getClones();
         $this->assertCount(1, $clones);
+    }
+
+    /**
+     * @covers SebastianBergmann\PHPCPD\Detector\Detector::copyPasteDetection
+     * @dataProvider strategyProvider
+     *
+     * @param string $strategy
+     */
+    public function testNullableTypeHints(string $strategy): void
+    {
+        $detector = new SebastianBergmann\PHPCPD\Detector\Detector(new $strategy);
+        $clones   = $detector->copyPasteDetection(
+            [
+                TEST_FILES_PATH . 'NullableTypeHint.php',
+            ],
+            2,
+            7,
+            true
+        );
+        $clones = $clones->getClones();
+        $this->assertCount(0, $clones);
     }
 
     public function strategyProvider()

--- a/tests/_files/NullableTypeHint.php
+++ b/tests/_files/NullableTypeHint.php
@@ -1,0 +1,17 @@
+<?php
+
+class NullableTypeHintA
+{
+    function foo(?string $foo): ?string
+    {
+        return $foo;
+    }
+}
+
+class NullableTypeHintB
+{
+    function foo(string $foo): string
+    {
+        return $foo;
+    }
+}


### PR DESCRIPTION
The problem is that `token_get_all` will interpret nullables as token `?` plus the type token. We currently strip all tokens which are no arrays. I have added a check which will change all `?` into full tokens. My problem with this hack is, that we now interpret ternary operators and nullable as the same token. 

This PR resolves #162 with a little hack. 