### PR TITLE
Fix uncaught type error by always returning an integer

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -103,7 +103,7 @@ final class Command extends AbstractCommand
     /**
      * Executes the current command.
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $finder = new FinderFacade(
             $input->getArgument('values'),
@@ -117,7 +117,7 @@ final class Command extends AbstractCommand
 
         if (empty($files)) {
             $output->writeln('No files found to scan');
-            exit(0);
+            return 0;
         }
 
         $progressBar = null;
@@ -162,8 +162,10 @@ final class Command extends AbstractCommand
         }
 
         if (\count($clones) > 0) {
-            exit(1);
+            return 1;
         }
+
+        return 0;
     }
 
     private function handleCSVOption(InputInterface $input, string $option): array


### PR DESCRIPTION
Hi!

Here is a fix for an issue when using the `dev-master` version with `PHP 7.3.12`.

This may be related to the recent upgrade to Symfony 5, as I received an uncaught type error because the `\SebastianBergmann\PHPCPD\CLI\Command::execute` method was not returning an exit code if no duplicates were found.

Basically, I've added a default `return 0` statement at the end of the method and converted the existing `exit` statements. It's less brutal and more "Symfony-friendly". :wink:

### Without my update
```
phpcpd 5.0-ged1b7d7 by Sebastian Bergmann.

No clones found.

Time: 428 ms, Memory: 8.00 MB

Fatal error: Uncaught TypeError: Return value of "SebastianBergmann\PHPCPD\CLI\Command::execute()" must be of the type int, NULL returned. in /root/.composer/vendor/symfony/console/Command/Command.php:258
Stack trace:
#0 /root/.composer/vendor/symfony/console/Application.php(924): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 /root/.composer/vendor/symfony/console/Application.php(265): Symfony\Component\Console\Application->doRunCommand(Object(SebastianBergmann\PHPCPD\CLI\Command), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /root/.composer/vendor/sebastian/phpcpd/src/CLI/Application.php(64): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /root/.composer/vendor/symfony/console/Application.php(141): SebastianBergmann\PHPCPD\CLI\Application->do in /root/.composer/vendor/symfony/console/Command/Command.php on line 258
```

### With my update
```
phpcpd 5.0-ged1b7d7 by Sebastian Bergmann.

No clones found.

Time: 653 ms, Memory: 8.00 MB
```