### PR TITLE
Update --min-lines to force it as a integer

### DIFF
--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -135,7 +135,7 @@ final class Command extends AbstractCommand
 
         $clones = $detector->copyPasteDetection(
             $files,
-            $input->getOption('min-lines'),
+            (int) $input->getOption('min-lines'),
             $input->getOption('min-tokens'),
             $input->getOption('fuzzy')
         );


### PR DESCRIPTION
Will fix #181 
Though Im not sure if it is the correct method.
But as symfony ArgvInput is missing type casting, I think this is the only way to fix it