### PR TITLE
Fix #190: Provide an option to allow a maximum percentage of duplicated code

### DIFF
--- a/src/CLI/Application.php
+++ b/src/CLI/Application.php
@@ -10,7 +10,6 @@
 namespace SebastianBergmann\PHPCPD;
 
 use const PHP_EOL;
-use function count;
 use function printf;
 use SebastianBergmann\FileIterator\Facade;
 use SebastianBergmann\PHPCPD\Detector\Detector;
@@ -88,7 +87,11 @@ final class Application
 
         print (new ResourceUsageFormatter)->resourceUsage($timer->stop()) . PHP_EOL;
 
-        return count($clones) > 0 ? 1 : 0;
+        if ($clones->percentage() > $arguments->maxPercentage()) {
+            return 1;
+        }
+
+        return 0;
     }
 
     private function printVersion(): void
@@ -136,6 +139,10 @@ Options for analysing files:
 Options for report generation:
 
   --log-pmd <file>  Write log in PMD-CPD XML format to <file>
+
+Options for Continuous Integration checking:
+
+  --max-percentage <N> Maximum percentage of duplicated code allowed (default: 0)
 
 EOT;
     }

--- a/src/CLI/Arguments.php
+++ b/src/CLI/Arguments.php
@@ -32,6 +32,8 @@ final class Arguments
 
     private int $tokensThreshold;
 
+    private float $maxPercentage;
+
     private bool $fuzzy;
 
     private bool $verbose;
@@ -46,7 +48,7 @@ final class Arguments
 
     private int $headEquality;
 
-    public function __construct(array $directories, array $suffixes, array $exclude, ?string $pmdCpdXmlLogfile, int $linesThreshold, int $tokensThreshold, bool $fuzzy, bool $verbose, bool $help, bool $version, ?string $algorithm, int $editDistance, int $headEquality)
+    public function __construct(array $directories, array $suffixes, array $exclude, ?string $pmdCpdXmlLogfile, int $linesThreshold, int $tokensThreshold, float $maxPercentage, bool $fuzzy, bool $verbose, bool $help, bool $version, ?string $algorithm, int $editDistance, int $headEquality)
     {
         $this->directories      = $directories;
         $this->suffixes         = $suffixes;
@@ -54,6 +56,7 @@ final class Arguments
         $this->pmdCpdXmlLogfile = $pmdCpdXmlLogfile;
         $this->linesThreshold   = $linesThreshold;
         $this->tokensThreshold  = $tokensThreshold;
+        $this->maxPercentage    = $maxPercentage;
         $this->fuzzy            = $fuzzy;
         $this->verbose          = $verbose;
         $this->help             = $help;
@@ -100,6 +103,11 @@ final class Arguments
     public function tokensThreshold(): int
     {
         return $this->tokensThreshold;
+    }
+
+    public function maxPercentage(): float
+    {
+        return $this->maxPercentage;
     }
 
     public function fuzzy(): bool

--- a/src/CLI/ArgumentsBuilder.php
+++ b/src/CLI/ArgumentsBuilder.php
@@ -32,6 +32,7 @@ final class ArgumentsBuilder
                     'min-tokens=',
                     'head-equality=',
                     'edit-distance=',
+                    'max-percentage=',
                     'verbose',
                     'help',
                     'version',
@@ -54,6 +55,7 @@ final class ArgumentsBuilder
         $tokensThreshold  = 70;
         $editDistance     = 5;
         $headEquality     = 10;
+        $maxPercentage    = 0;
         $fuzzy            = false;
         $verbose          = false;
         $help             = false;
@@ -100,6 +102,15 @@ final class ArgumentsBuilder
                 case '--edit-distance':
                     $editDistance = (int) $option[1];
 
+                case '--max-percentage':
+                    $maxPercentage = (float) $option[1];
+
+                    if ($maxPercentage < 0 || $maxPercentage > 100) {
+                        throw new ArgumentsBuilderException(
+                            'Maximum percentage allowed must be between 0 and 100'
+                        );
+                    }
+
                     break;
 
                 case '--verbose':
@@ -139,6 +150,7 @@ final class ArgumentsBuilder
             $pmdCpdXmlLogfile,
             $linesThreshold,
             $tokensThreshold,
+            $maxPercentage,
             $fuzzy,
             $verbose,
             $help,

--- a/src/CodeCloneMap.php
+++ b/src/CodeCloneMap.php
@@ -69,15 +69,20 @@ final class CodeCloneMap implements Countable, IteratorAggregate
         return $this->clones;
     }
 
-    public function percentage(): string
+    public function percentage(): float
     {
         if ($this->numberOfLines > 0) {
-            $percent = ($this->numberOfDuplicatedLines / $this->numberOfLines) * 100;
+            $percentage = ($this->numberOfDuplicatedLines / $this->numberOfLines) * 100;
         } else {
-            $percent = 100;
+            $percentage = 100;
         }
 
-        return sprintf('%01.2F%%', $percent);
+        return $percentage;
+    }
+
+    public function percentageRounded(): string
+    {
+        return sprintf('%01.2F%%', $this->percentage());
     }
 
     public function numberOfLines(): int

--- a/src/CodeCloneMap.php
+++ b/src/CodeCloneMap.php
@@ -80,7 +80,7 @@ final class CodeCloneMap implements Countable, IteratorAggregate
         return $percentage;
     }
 
-    public function percentageRounded(): string
+    public function percentageAsString(): string
     {
         return sprintf('%01.2F%%', $this->percentage());
     }

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -59,7 +59,7 @@ final class Text
         printf(
             '%s duplicated lines out of %d total lines of code.' . PHP_EOL .
             'Average code clone size is %d lines, the largest code clone has %d lines' . PHP_EOL . PHP_EOL,
-            $clones->percentageRounded(),
+            $clones->percentageAsString(),
             $clones->numberOfLines(),
             $clones->averageSize(),
             $clones->largestSize()

--- a/src/Log/Text.php
+++ b/src/Log/Text.php
@@ -59,7 +59,7 @@ final class Text
         printf(
             '%s duplicated lines out of %d total lines of code.' . PHP_EOL .
             'Average code clone size is %d lines, the largest code clone has %d lines' . PHP_EOL . PHP_EOL,
-            $clones->percentage(),
+            $clones->percentageRounded(),
             $clones->numberOfLines(),
             $clones->averageSize(),
             $clones->largestSize()


### PR DESCRIPTION
UnitTest and PHPCS verified.

Here are the usages

<details>
  <summary>When no option is given</summary>
  
![no-option](https://user-images.githubusercontent.com/9560327/127682522-c44410af-2d9e-4296-9452-a5d40ca8716e.png)

</details>

<details>
  <summary>When option is given and CI should be in success</summary>
  
![option-success](https://user-images.githubusercontent.com/9560327/127682592-7f2ca5f6-eb06-4dea-acd2-bc2b069fee84.png)

</details>

<details>
  <summary>When option is given and CI must be in failure</summary>
  
![option-failure](https://user-images.githubusercontent.com/9560327/127682624-9f310e90-76b5-4766-8f6a-b1ebb6fd8be6.png)

</details>

<details>
  <summary>When option is given but out of bounds</summary>
  
![option-bounds](https://user-images.githubusercontent.com/9560327/127682677-8e63854e-e2be-49d2-80c5-e3fe44bab030.png)

</details>


Current implementation makes return `1` when a single copy-paste is detected. That's why the default `--max-percentage` value I chose is 0.